### PR TITLE
Split turbo-specific features from EditorWindow into a subclass

### DIFF
--- a/src/app.cc
+++ b/src/app.cc
@@ -265,7 +265,8 @@ void TurboApp::fileOpen()
 bool TurboApp::openEditor(std::string_view fileName, bool canFail)
 {
     TRect r = newEditorBounds();
-    EditorWindow *w = new EditorWindow(r, fileName, canFail);
+    EditorWindow *w = new EditorWindow(r);
+    w->setUpEditor(fileName, canFail);
     w = (EditorWindow *) validView(w);
     if (w)
         addEditor(w);

--- a/src/clipboard.cc
+++ b/src/clipboard.cc
@@ -15,11 +15,22 @@ void Clipboard::syncSetText(std::string_view text)
 {
     if (cb)
         clipboard_set_text_ex(cb, text.data(), (int) text.size(), LCB_CLIPBOARD);
+    else
+        fallbackSetText(text);
 }
 
 const char* Clipboard::syncGetText()
 {
     if (cb)
         return clipboard_text(cb);
-    return nullptr;
+
+    return fallbackGetText();
+}
+
+void Clipboard::fallbackSetText(std::string_view) {
+    // no-op
+}
+
+char* Clipboard::fallbackGetText() {
+    return nullptr; // no-op
 }

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -13,10 +13,15 @@ class Clipboard {
     void syncSetText(std::string_view);
     const char* syncGetText();
 
+protected:
+
+    virtual void fallbackSetText(std::string_view);
+    virtual char* fallbackGetText();
+
 public:
 
     Clipboard();
-    ~Clipboard();
+    virtual ~Clipboard();
 
     template <class Func>
     void copy(Func &&fillSel)

--- a/src/docview.cc
+++ b/src/docview.cc
@@ -10,7 +10,7 @@ using namespace Scintilla;
 DocumentView::DocumentView( const TRect &bounds,
                             const TDrawSurface *view,
                             Scintilla::TScintillaEditor &aEditor,
-                            EditorWindow &aWindow ) :
+                            BaseEditorWindow &aWindow ) :
     TSurfaceView(bounds, view),
     editor(aEditor),
     window(aWindow)

--- a/src/docview.h
+++ b/src/docview.h
@@ -6,17 +6,17 @@
 
 #include "tscintilla.h"
 
-struct EditorWindow;
+struct BaseEditorWindow;
 
 struct DocumentView : public TSurfaceView {
 
     Scintilla::TScintillaEditor &editor;
-    EditorWindow &window;
+    BaseEditorWindow &window;
 
     DocumentView( const TRect &bounds,
                   const TDrawSurface *view,
                   Scintilla::TScintillaEditor &aEditor,
-                  EditorWindow &aWindow );
+                  BaseEditorWindow &aWindow );
 
     void handleEvent(TEvent &ev) override;
     void draw() override;

--- a/src/editframe.h
+++ b/src/editframe.h
@@ -4,12 +4,12 @@
 #define Uses_TFrame
 #include <tvision/tv.h>
 
-struct EditorWindow;
+struct BaseEditorWindow;
 
 struct EditorFrame : public TFrame
 {
 
-    EditorWindow *editwin;
+    BaseEditorWindow *editwin;
 
     EditorFrame(const TRect &bounds);
 

--- a/src/editwindow.cc
+++ b/src/editwindow.cc
@@ -52,6 +52,19 @@ BaseEditorWindow::BaseEditorWindow( const TRect &bounds ) :
     insert(docView);
 
     SearchBox::init(*this);
+}
+
+EditorWindow::EditorWindow( const TRect &bounds )
+    : TWindowInit(&initFrame),
+      BaseEditorWindow(bounds),
+      MRUhead(this),
+      fatalError(false),
+      inSavePoint(true)
+{
+    setState(sfShadow, False);
+
+    if (TurboApp::app)
+        editor.clipboard = &TurboApp::app->clipboard;
 
     // Commands that always get enabled when focusing the editor.
     enabledCmds += cmSave;
@@ -67,19 +80,6 @@ BaseEditorWindow::BaseEditorWindow( const TRect &bounds ) :
     // Commands that always get disabled when unfocusing the editor.
     disabledCmds += enabledCmds;
     disabledCmds += cmRename;
-}
-
-EditorWindow::EditorWindow( const TRect &bounds )
-    : TWindowInit(&initFrame),
-      BaseEditorWindow(bounds),
-      MRUhead(this),
-      fatalError(false),
-      inSavePoint(true)
-{
-    setState(sfShadow, False);
-
-    if (TurboApp::app)
-        editor.clipboard = &TurboApp::app->clipboard;
 }
 
 BaseEditorWindow::~BaseEditorWindow()
@@ -315,13 +315,6 @@ void BaseEditorWindow::setState(ushort aState, Boolean enable)
                 break;
         }
     }
-    switch (aState) {
-        // These actions do not depend on subview lifetime.
-        case sfActive:
-            updateCommands();
-            break;
-    }
-
 }
 
 void EditorWindow::setState(ushort aState, Boolean enable)
@@ -334,6 +327,13 @@ void EditorWindow::setState(ushort aState, Boolean enable)
                     TurboApp::app->setFocusedEditor(this);
                 break;
         }
+    }
+
+    switch (aState) {
+        // These actions do not depend on subview lifetime.
+        case sfActive:
+            updateCommands();
+            break;
     }
 }
 
@@ -366,7 +366,7 @@ void BaseEditorWindow::sizeLimits( TPoint& min, TPoint& max )
     min = minEditWinSize;
 }
 
-void BaseEditorWindow::updateCommands()
+void EditorWindow::updateCommands()
 {
     if (state & sfActive)
         enableCommands(enabledCmds);

--- a/src/editwindow.cc
+++ b/src/editwindow.cc
@@ -31,7 +31,6 @@ BaseEditorWindow::BaseEditorWindow( const TRect &bounds ) :
     ((EditorFrame *) frame)->editwin = this;
 
     options |= ofTileable | ofFirstClick;
-    setState(sfShadow, False);
 
     hScrollBar = new TScrollBar(TRect( 18, size.y - 1, size.x - 2, size.y ));
     hScrollBar->hide();
@@ -77,6 +76,8 @@ EditorWindow::EditorWindow( const TRect &bounds )
       fatalError(false),
       inSavePoint(true)
 {
+    setState(sfShadow, False);
+
     if (TurboApp::app)
         editor.clipboard = &TurboApp::app->clipboard;
 }

--- a/src/editwindow.cc
+++ b/src/editwindow.cc
@@ -232,6 +232,11 @@ void BaseEditorWindow::handleEvent(TEvent &ev) {
             clearEvent(ev);
         }
     }
+    TWindow::handleEvent(ev);
+}
+
+void EditorWindow::handleEvent(TEvent &ev)
+{
     if (ev.what == evCommand) {
         bool handled = true;
         switch (ev.message.command) {
@@ -258,11 +263,6 @@ void BaseEditorWindow::handleEvent(TEvent &ev) {
         if (handled)
             clearEvent(ev);
     }
-    TWindow::handleEvent(ev);
-}
-
-void EditorWindow::handleEvent(TEvent &ev)
-{
     BaseEditorWindow::handleEvent(ev);
     if (ev.what == evCommand) {
         switch (ev.message.command) {

--- a/src/editwindow.h
+++ b/src/editwindow.h
@@ -32,7 +32,6 @@ struct BaseEditorWindow : public TWindow, Scintilla::TScintillaWindow {
     TSurfaceView *leftMargin;
     SearchBox *search;
     TScrollBar *hScrollBar, *vScrollBar;
-    TCommandSet enabledCmds, disabledCmds;
     bool drawing;
     bool resizeLock;
     TPoint lastSize;
@@ -66,7 +65,6 @@ struct BaseEditorWindow : public TWindow, Scintilla::TScintillaWindow {
     void sizeLimits(TPoint &min, TPoint &max) override;
     static constexpr TPoint minEditWinSize {24, 6};
 
-    void updateCommands();
     void lockSubViews();
     void unlockSubViews();
     void scrollBarEvent(TEvent ev);
@@ -89,6 +87,9 @@ struct EditorWindow : public BaseEditorWindow {
     const char* getTitle(short) override;
     void notify(SCNotification scn) override;
     TPalette& getPalette() const override;
+    void updateCommands();
+
+    TCommandSet enabledCmds, disabledCmds;
 
     // TurboApp integration
 

--- a/src/editwindow.h
+++ b/src/editwindow.h
@@ -100,7 +100,7 @@ struct EditorWindow : public BaseEditorWindow {
     // no file is open.
 
     std::string file;
-    virtual void setFile(std::string); // Use this setter to update the string.
+    void setFile(std::string); // Use this setter to update the string.
 
     // If there was an error while loading the file, the view is invalid.
     // It shall return False when invoking valid(cmValid).

--- a/src/search.cc
+++ b/src/search.cc
@@ -10,7 +10,7 @@
 #include "editwindow.h"
 #include "docview.h"
 
-void SearchBox::init(EditorWindow &win)
+void SearchBox::init(BaseEditorWindow &win)
 {
     TRect r = win.getExtent().grow(-1, -1);
     r.a.y = r.b.y - 2;
@@ -21,7 +21,7 @@ void SearchBox::init(EditorWindow &win)
     win.insert(box);
 }
 
-SearchBox::SearchBox(const TRect &bounds, EditorWindow &win) :
+SearchBox::SearchBox(const TRect &bounds, BaseEditorWindow &win) :
     TGroup(bounds),
     visible(false)
 {
@@ -135,7 +135,7 @@ static inline void grow(TView *v, TPoint delta)
 void SearchBox::open()
 {
     if (!visible && owner) {
-        EditorWindow &win = *(EditorWindow *) owner;
+        BaseEditorWindow &win = *(BaseEditorWindow *) owner;
         win.lock();
         win.editorView.grow({0, -(size.y + 1)});
         for (auto *v : std::initializer_list<TView*> {win.docView, win.leftMargin})
@@ -154,7 +154,7 @@ void SearchBox::open()
 void SearchBox::close()
 {
     if (visible && owner) {
-        EditorWindow &win = *(EditorWindow *) owner;
+        BaseEditorWindow &win = *(BaseEditorWindow *) owner;
         win.lock();
         win.editorView.grow({0, size.y + 1});
         for (auto *v : std::initializer_list<TView*> {win.docView, win.leftMargin})

--- a/src/search.h
+++ b/src/search.h
@@ -8,11 +8,11 @@
 #include <tvision/tv.h>
 #include <string_view>
 
-struct EditorWindow;
+struct BaseEditorWindow;
 
 struct SearchBox : public TGroup {
 
-    SearchBox(const TRect &bounds, EditorWindow &win);
+    SearchBox(const TRect &bounds, BaseEditorWindow &win);
 
     TInputLine *findBox;
     bool visible;
@@ -22,18 +22,18 @@ struct SearchBox : public TGroup {
     void open();
     void close();
 
-    static void init(EditorWindow &win);
+    static void init(BaseEditorWindow &win);
 
 };
 
 struct Searcher : public TValidator {
 
-    EditorWindow &win;
+    BaseEditorWindow &win;
     bool onDemand {false}, typing {false};
     sptr_t result, resultEnd;
     enum {forward=0, backwards=1} direction;
 
-    Searcher(EditorWindow &win) :
+    Searcher(BaseEditorWindow &win) :
         win(win)
     {
     }

--- a/src/styles.cc
+++ b/src/styles.cc
@@ -420,7 +420,7 @@ static const std::unordered_map<Language, LexerInfo> lexerStyles = {
     {langRuby, {SCLEX_RUBY, stylesRuby, keywordsRuby, nullptr, bracesC}},
 };
 
-void ThemingState::loadLexer(Language lang, EditorWindow &win)
+void ThemingState::loadLexer(Language lang, BaseEditorWindow &win)
 {
     auto &editor = win.editor;
     auto it = lexerStyles.find(lang);
@@ -460,7 +460,7 @@ TColorAttr ThemingState::normalize(Styles index) const
     return normal;
 }
 
-void ThemingState::resetStyles(EditorWindow &win) const
+void ThemingState::resetStyles(BaseEditorWindow &win) const
 {
     auto &editor = win.editor;
     editor.setStyleColor(STYLE_DEFAULT, schema[sNormal]);

--- a/src/styles.h
+++ b/src/styles.h
@@ -4,6 +4,7 @@
 #include <tvision/tv.h>
 #include <utility>
 
+struct BaseEditorWindow;
 struct EditorWindow;
 struct LexerInfo;
 struct TColorAttr;
@@ -89,14 +90,14 @@ struct ThemingState
 
     ThemingState();
 
-    void resetStyles(EditorWindow &win) const;
+    void resetStyles(BaseEditorWindow &win) const;
     void detectLanguage(EditorWindow &win);
     void updateBraces(Scintilla::TScintillaEditor &editor) const;
     TColorAttr normalize(Styles) const;
 
 private:
 
-    void loadLexer(Language lang, EditorWindow &win);
+    void loadLexer(Language lang, BaseEditorWindow &win);
     TColorAttr braceAttr(LexerStyles, uchar) const;
 
 };

--- a/src/tscintilla.cc
+++ b/src/tscintilla.cc
@@ -135,6 +135,12 @@ void TScintillaEditor::NotifyParent(SCNotification scn)
         parent->notify(scn);
 }
 
+void TScintillaEditor::NotifyStyleToNeeded(Sci::Position endStyleNeeded)
+{
+    if (parent)
+        parent->notifyStyleToNeeded(endStyleNeeded);
+}
+
 void TScintillaEditor::CopyToClipboard(const SelectionText &selectedText)
 {
 }

--- a/src/tscintilla.h
+++ b/src/tscintilla.h
@@ -35,6 +35,7 @@ struct TScintillaEditor : public ScintillaBase {
     void ClaimSelection() override;
     void NotifyChange() override;
     void NotifyParent(SCNotification scn) override;
+    void NotifyStyleToNeeded(Sci::Position endStyleNeeded) override;
     void CopyToClipboard(const SelectionText &selectedText) override;
     bool FineTickerRunning(TickReason reason) override;
     void FineTickerStart(TickReason reason, int millis, int tolerance) override;
@@ -127,6 +128,7 @@ public:
     virtual void notify(SCNotification scn) {};
     virtual void setVerticalScrollPos(int delta, int limit) = 0;
     virtual void setHorizontalScrollPos(int delta, int limit) = 0;
+    virtual void notifyStyleToNeeded(Sci::Position endStyleNeeded) {};
 
 };
 


### PR DESCRIPTION
This code was hastily prepared and I don't expect it to be mergeable as-is, but it can serve as a proof of concept for the desired division of responsibilities.

I refactored the `EditorWindow` class so that everything turbo-specific (generally the window management and file handling stuff) is in a subclass (still called `EditorWindow`), with a new `BaseEditorWindow` class offering a convenient extension point for external users. I've implemented a subclass of `BaseEditorWindow` in tmbasic and it seems to be working ok. I haven't finished the integration work, but I don't think any upstream changes are required for the rest.

I also extended the `Clipboard` class to allow a subclass to implement fallback behavior when libclipboard fails.