### PR TITLE
Add support for setting clipboard using OSC 52 escape sequence

### DIFF
--- a/include/turbo/base64.h
+++ b/include/turbo/base64.h
@@ -1,0 +1,84 @@
+// from https://github.com/tobiaslocker/base64
+// License: MIT
+
+#ifndef BASE_64_HPP
+#define BASE_64_HPP
+
+#include <algorithm>
+#include <string>
+
+namespace turbo {
+
+inline std::string get_base64_chars() {
+    static std::string base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                   "abcdefghijklmnopqrstuvwxyz"
+                                   "0123456789+/";
+    return base64_chars;
+}
+
+inline std::string to_base64(std::string const &data) {
+  int counter = 0;
+  uint32_t bit_stream = 0;
+  const std::string base64_chars = get_base64_chars();
+  std::string encoded;
+  int offset = 0;
+  for (unsigned char c : data) {
+    auto num_val = static_cast<unsigned int>(c);
+    offset = 16 - counter % 3 * 8;
+    bit_stream += num_val << offset;
+    if (offset == 16) {
+      encoded += base64_chars.at(bit_stream >> 18 & 0x3f);
+    }
+    if (offset == 8) {
+      encoded += base64_chars.at(bit_stream >> 12 & 0x3f);
+    }
+    if (offset == 0 && counter != 3) {
+      encoded += base64_chars.at(bit_stream >> 6 & 0x3f);
+      encoded += base64_chars.at(bit_stream & 0x3f);
+      bit_stream = 0;
+    }
+    counter++;
+  }
+  if (offset == 16) {
+    encoded += base64_chars.at(bit_stream >> 12 & 0x3f);
+    encoded += "==";
+  }
+  if (offset == 8) {
+    encoded += base64_chars.at(bit_stream >> 6 & 0x3f);
+    encoded += '=';
+  }
+  return encoded;
+}
+
+inline std::string from_base64(std::string const &data) {
+  int counter = 0;
+  uint32_t bit_stream = 0;
+  std::string decoded;
+  int offset = 0;
+  const std::string base64_chars = get_base64_chars();
+  for (unsigned char c : data) {
+    auto num_val = base64_chars.find(c);
+    if (num_val != std::string::npos) {
+      offset = 18 - counter % 4 * 6;
+      bit_stream += num_val << offset;
+      if (offset == 12) {
+        decoded += static_cast<char>(bit_stream >> 16 & 0xff);
+      }
+      if (offset == 6) {
+        decoded += static_cast<char>(bit_stream >> 8 & 0xff);
+      }
+      if (offset == 0 && counter != 4) {
+        decoded += static_cast<char>(bit_stream & 0xff);
+        bit_stream = 0;
+      }
+    } else if (c != '=') {
+      return std::string();
+    }
+    counter++;
+  }
+  return decoded;
+}
+
+}
+
+#endif // BASE_64_HPP

--- a/source/turbo-core/clipboard.cc
+++ b/source/turbo-core/clipboard.cc
@@ -1,6 +1,7 @@
 #include <turbo/clipboard.h>
 #include <libclipboard.h>
 #include <turbo/scintilla/internals.h>
+#include <turbo/base64.h>
 
 namespace turbo {
 
@@ -56,6 +57,13 @@ SystemClipboard::~SystemClipboard()
 
 bool SystemClipboard::xSetText(TStringView text) noexcept
 {
+    #if !defined( _WIN32 )
+    // Try to set clipboard via OSC 52 escape sequence on *nix platforms
+    std::string encoded = turbo::to_base64(text.data());
+    printf("\e]52;;%s\a", encoded.c_str());
+    fflush(stdout);
+    #endif
+
     return cb && clipboard_set_text_ex(cb, text.data(), (int) text.size(), LCB_CLIPBOARD);
 }
 

--- a/source/turbo-core/clipboard.cc
+++ b/source/turbo-core/clipboard.cc
@@ -60,6 +60,7 @@ bool SystemClipboard::xSetText(TStringView text) noexcept
     bool cb_set_result = clipboard_set_text_ex(cb, text.data(), (int) text.size(), LCB_CLIPBOARD);
 
 #if !defined( _WIN32 )
+#if !defined( __BORLANDC__ )
     if (!cb_set_result) {
         // Try to set clipboard via OSC 52 escape sequence on *nix platforms
         std::string encoded = turbo::to_base64(text.data());
@@ -67,7 +68,8 @@ bool SystemClipboard::xSetText(TStringView text) noexcept
         fflush(stdout);
     }
 #endif
-
+#endif
+    
     return cb && cb_set_result;
 }
 


### PR DESCRIPTION
Useful if X11 is not available.

OSC 52 support table:
https://github.com/ojroques/vim-oscyank#vim-oscyank