### PR TITLE
Add support for opening current dir on start

### DIFF
--- a/source/turbo/app.cc
+++ b/source/turbo/app.cc
@@ -26,9 +26,11 @@
 #include "doctree.h"
 #include <turbo/fileeditor.h>
 #include <turbo/tpath.h>
+#include <filesystem>
 
 using namespace Scintilla;
 using namespace std::literals;
+using namespace std::filesystem;
 
 TurboApp* TurboApp::app = 0;
 
@@ -263,11 +265,22 @@ void TurboApp::parseArgs()
         auto *current = new TParamText(TRect(2, 3, 48, 9));
         w->insert(current);
         insert(w);
-        for (int i = 1; i < argc; ++i) {
-            current->setText("%s", argv[i]);
-            TScreen::flushScreen();
-            fileOpenOrNew(argv[i]);
+
+        if (argc == 2 && std::string(argv[1]) == ".")
+        {
+            for (const auto& dirEntry : recursive_directory_iterator(argv[1])) {
+                current->setText("%s", dirEntry.path().string().c_str());
+                TScreen::flushScreen();
+                fileOpenOrNew(dirEntry.path().string().c_str());
+            }
+        } else {
+            for (int i = 1; i < argc; ++i) {
+                current->setText("%s", argv[i]);
+                TScreen::flushScreen();
+                fileOpenOrNew(argv[i]);
+            }
         }
+
         remove(w);
         TObject::destroy(w);
     }

--- a/source/turbo/app.cc
+++ b/source/turbo/app.cc
@@ -266,7 +266,9 @@ void TurboApp::parseArgs()
         w->insert(current);
         insert(w);
 
-        if (argc == 2 && std::string(argv[1]) == ".")
+        const std::string pathString = std::string(argv[1]);
+        const path path(pathString);
+        if (argc == 2 && is_directory(path))
         {
             for (const auto& dirEntry : recursive_directory_iterator(argv[1])) {
                 current->setText("%s", dirEntry.path().string().c_str());


### PR DESCRIPTION
Hej,

First, I would like to say thank you for your modern port of Turbo Vision and especially for the `turbo` editor! I like the editor a lot and use it almost daily since I read about your Turbo Vision port on HackerNews some weeks ago.

As far as I understand,   The `turbo` editor can take file paths  as parameters on startup. These files are loaded then.
I was missing that I could just start `turbo` with a pointer to the current directory, e.g., with `turbo .` or any other directory where then all files within this directory would be loaded.

The change in this PR implements that feature. Since I am not a C++ programmer, my change might be weird. Please let me know if I should change anything.  