### PR TITLE
Implement recently opened files feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Below is a TO-DO list of features I would like to implement in Turbo:
 - [x] Find as you type.
 - [x] Replace.
 - [x] Go to line.
-- [ ] List of recently opened files.
+- [x] List of recently opened files.
 - [x] Remove trailing whitespaces on save.
 - [x] Ensure newline at end of file.
 - [ ] Detect open files modified on disk.

--- a/source/turbo/app.cc
+++ b/source/turbo/app.cc
@@ -107,6 +107,7 @@ TMenuBar *TurboApp::initMenuBar(TRect r)
         *new TSubMenu( "~F~ile", kbAltF, hcNoContext ) +
             *new TMenuItem( "~N~ew", cmNew, kbCtrlN, hcNoContext, "Ctrl-N" ) +
             *new TMenuItem( "~O~pen", cmOpen, kbCtrlO, hcNoContext, "Ctrl-O" ) +
+            *new TMenuItem( "Open ~R~ecent...", cmOpenRecent, kbNoKey, hcNoContext ) +
             newLine() +
             *new TMenuItem( "~S~ave", cmSave, kbCtrlS, hcNoContext, "Ctrl-S" ) +
             *new TMenuItem( "S~a~ve As...", cmSaveAs, kbNoKey, hcNoContext ) +
@@ -219,6 +220,7 @@ void TurboApp::handleEvent(TEvent &event)
         switch (event.message.command) {
             case cmNew: fileNew(); break;
             case cmOpen: fileOpen(); break;
+            case cmOpenRecent: showRecentFiles(); break;
             case cmEditorNext:
             case cmEditorPrev:
                 showEditorList(&event);
@@ -294,6 +296,39 @@ void TurboApp::fileOpenOrNew(const char *path)
         addEditor(scintilla, abspath);
 }
 
+void TurboApp::addRecentFile(const std::string &path)
+{
+    // Remove duplicates, then prepend.
+    for (auto it = recentFiles.begin(); it != recentFiles.end(); ++it)
+    {
+        if (*it == path)
+        {
+            recentFiles.erase(it);
+            break;
+        }
+    }
+    recentFiles.push_front(path);
+    if (recentFiles.size() > maxRecentFiles)
+        recentFiles.pop_back();
+}
+
+void TurboApp::showRecentFiles()
+{
+    if (recentFiles.empty())
+        return;
+    RecentFilesListModel model {recentFiles};
+    TRect r {0, 0, 0, 0};
+    r.b.x = min(max(ListModel::maxItemCStrLen(model) + 4, 40), deskTop->size.x - 10);
+    r.b.y = min(max((int) model.size() + 2, 6), deskTop->size.y - 4);
+    r.move((deskTop->size.x - r.b.x) / 2,
+           (deskTop->size.y - r.b.y) / 4);
+    ListWindow *lw = &ListWindow::create(r, "Recent Files", model, lvScrollBars | lvSelectSingleClick);
+    if (deskTop->execView(lw) == cmOK)
+        if (auto *path = (const std::string *) lw->getCurrent())
+            fileOpenOrNew(path->c_str());
+    destroy(lw);
+}
+
 void TurboApp::closeAll()
 {
     while (!MRUlist.empty()) {
@@ -341,6 +376,8 @@ void TurboApp::addEditor(turbo::TScintilla &scintilla, const char *path)
     w.listHead.insert_after(&MRUlist);
     deskTop->insert(&w);
     enableCommands(editorCmds);
+    if (path && path[0])
+        addRecentFile(path);
 }
 
 void TurboApp::showEditorList(TEvent *ev)
@@ -428,6 +465,8 @@ void TurboApp::handleTitleChange(EditorWindow &w) noexcept
 
 void TurboApp::removeEditor(EditorWindow &w) noexcept
 {
+    if (!w.filePath().empty())
+        addRecentFile(w.filePath());
     w.listHead.remove();
     if (MRUlist.empty())
         disableCommands(editorCmds);

--- a/source/turbo/app.h
+++ b/source/turbo/app.h
@@ -11,11 +11,15 @@
 #include "editwindow.h"
 #include "cmds.h"
 
+#include <deque>
+
 struct EditorWindow;
 class TClockView;
 
 struct TurboApp : public TApplication, EditorWindowParent
 {
+
+    static constexpr size_t maxRecentFiles = 20;
 
     FileCounter fileCount;
     list_head<EditorWindow> MRUlist;
@@ -27,6 +31,7 @@ struct TurboApp : public TApplication, EditorWindowParent
     const char **argv;
     turbo::SearchSettings searchSettings;
     std::string mostRecentDir;
+    std::deque<std::string> recentFiles;
 
     TurboApp(int argc, const char **argv) noexcept;
     static TMenuBar* initMenuBar(TRect r);
@@ -41,6 +46,8 @@ struct TurboApp : public TApplication, EditorWindowParent
     void fileNew();
     void fileOpen();
     void fileOpenOrNew(const char *path);
+    void showRecentFiles();
+    void addRecentFile(const std::string &path);
     void closeAll();
     TRect newEditorBounds() const;
     turbo::TScintilla &createScintilla() noexcept;

--- a/source/turbo/cmds.h
+++ b/source/turbo/cmds.h
@@ -26,7 +26,8 @@ enum : ushort
     cmReplaceOne,
     cmReplaceAll,
     // Commands that cannot be disabled.
-    cmToggleTree = 1000,
+    cmOpenRecent = 1000,
+    cmToggleTree,
     cmStateChanged,
     cmFindFindBox,
     cmFindGoToLineBox,

--- a/source/turbo/listviews.cc
+++ b/source/turbo/listviews.cc
@@ -297,3 +297,23 @@ std::string EditorListModel::getText(void *item) const noexcept
     }
     return text;
 }
+
+/////////////////////////////////////////////////////////////////////////
+// RecentFilesListModel
+
+size_t RecentFilesListModel::size() const noexcept
+{
+    return list.size();
+}
+
+void *RecentFilesListModel::at(size_t i) const noexcept
+{
+    return (i < list.size()) ? (void *) &list[i] : nullptr;
+}
+
+std::string RecentFilesListModel::getText(void *item) const noexcept
+{
+    if (auto *path = (const std::string *) item)
+        return *path;
+    return {};
+}

--- a/source/turbo/listviews.h
+++ b/source/turbo/listviews.h
@@ -130,6 +130,9 @@ public:
 #include "apputils.h"
 #include "editwindow.h"
 
+#include <deque>
+#include <string>
+
 class EditorListModel : public ListModel
 {
     mutable list_head_iterator<EditorWindow> list;
@@ -138,6 +141,23 @@ public:
 
     EditorListModel(list_head<EditorWindow> &aList) :
         list(&aList)
+    {
+    }
+
+    size_t size() const noexcept override;
+    void *at(size_t i) const noexcept override;
+    std::string getText(void *item) const noexcept override;
+};
+
+class RecentFilesListModel : public ListModel
+{
+    const std::deque<std::string> &list;
+
+public:
+
+    // The lifetime of 'aList' must exceed that of 'this'.
+    RecentFilesListModel(const std::deque<std::string> &aList) noexcept :
+        list(aList)
     {
     }
 


### PR DESCRIPTION
This pull request implements a "recent files" feature in Turbo, allowing users to view and quickly reopen recently accessed files. The main changes include tracking recently opened files, adding a menu item to access them, and displaying a dialog for selection. Supporting data structures and commands were also introduced.

**Recent files feature implementation:**

* Added a `recentFiles` deque to `TurboApp` to track recently opened files, with a maximum of 20 entries. Methods `addRecentFile` and `showRecentFiles` manage this list and display a selection dialog. (`source/turbo/app.h` [[1]](diffhunk://#diff-bb778f90ed0e6e9646e41935ef573d4b8bc99b8c76cdc910b19fed1f7b8601a8R14-R23) [[2]](diffhunk://#diff-bb778f90ed0e6e9646e41935ef573d4b8bc99b8c76cdc910b19fed1f7b8601a8R34) [[3]](diffhunk://#diff-bb778f90ed0e6e9646e41935ef573d4b8bc99b8c76cdc910b19fed1f7b8601a8R49-R50); `source/turbo/app.cc` [[4]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR299-R331) [[5]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR379-R380) [[6]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR468-R469)
* Integrated recent file tracking into editor actions: files are added to the recent list when opened or closed. (`source/turbo/app.cc` [[1]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR379-R380) [[2]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR468-R469)
* Added a "Open Recent..." menu item to the File menu, triggering the recent files dialog. (`source/turbo/app.cc` [source/turbo/app.ccR110](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR110))
* Defined a new command `cmOpenRecent` and handled it in the event loop. (`source/turbo/cmds.h` [[1]](diffhunk://#diff-78314ee9d1f70f68eacce107fc38ce78d5fd46c4181a58ce7826b8696d0f8892L29-R30); `source/turbo/app.cc` [[2]](diffhunk://#diff-9cdbb1e916a5770a96d7cf62c966cf18047e303f4e19a8f5efe39102f66b093fR223)

**UI support:**

* Added `RecentFilesListModel` to display recent files in a list window, with methods to provide item count, access, and display text. (`source/turbo/listviews.h` [[1]](diffhunk://#diff-c9e1926b0ddcf370a9d5e65bce84c159ebdaf46a0f8dca50ead71bdec76dabc9R133-R135) [[2]](diffhunk://#diff-c9e1926b0ddcf370a9d5e65bce84c159ebdaf46a0f8dca50ead71bdec76dabc9R152-R168); `source/turbo/listviews.cc` [[3]](diffhunk://#diff-d4e202c48892d77bd7753838d0fefc904704fd4f20c83568f6d0625410ece1fdR300-R319)

**Documentation:**

* Updated `README.md` to mark "List of recently opened files" as implemented.